### PR TITLE
Fix bug where executing a single command (with no arguments) would trigger shell expansion.

### DIFF
--- a/shirt
+++ b/shirt
@@ -60,7 +60,12 @@ def spawn_program(program, *arguments, placeholder_out, placeholder_in)
       placeholder_in.close
     end
 
-    exec program, *arguments
+    case arguments.empty?
+      when true
+        exec [program, ""]
+      else
+        exec program, *arguments
+    end
   }
 end
 

--- a/shirt
+++ b/shirt
@@ -60,11 +60,10 @@ def spawn_program(program, *arguments, placeholder_out, placeholder_in)
       placeholder_in.close
     end
 
-    case arguments.empty?
-      when true
-        exec [program, ""]
-      else
-        exec program, *arguments
+    if arguments.empty?
+      exec [program, ""]
+    else
+      exec program, *arguments
     end
   }
 end


### PR DESCRIPTION
As per issue #3, I've changed the script to handle this scenario. 

To reproduce the issue on the current version, just execute:

<code>
echo\ $SHELL
</code>

...And you should get your system shell echoed back to you.
